### PR TITLE
Increase gRPC message size defaults

### DIFF
--- a/armada/handlers/tiller.py
+++ b/armada/handlers/tiller.py
@@ -27,6 +27,13 @@ TILLER_VERSION = b'2.1.3'
 TILLER_TIMEOUT = 300
 RELEASE_LIMIT = 64
 
+# the standard gRPC max message size is 4MB
+# this expansion comes at a performance penalty
+# but until proper paging is supported, we need
+# to support a larger payload as the current
+# limit is exhausted with just 10 releases
+MAX_MESSAGE_LENGTH=4194304*10
+
 LOG = logging.getLogger(__name__)
 
 class Tiller(object):
@@ -61,7 +68,9 @@ class Tiller(object):
         '''
         tiller_ip = self._get_tiller_ip()
         tiller_port = self._get_tiller_port()
-        return grpc.insecure_channel('%s:%s' % (tiller_ip, tiller_port))
+        return grpc.insecure_channel('%s:%s' % (tiller_ip, tiller_port), options=\
+          [('grpc.max_send_message_length', MAX_MESSAGE_LENGTH), (
+            'grpc.max_receive_message_length', MAX_MESSAGE_LENGTH)])
 
     def _get_tiller_pod(self):
         '''

--- a/armada/handlers/tiller.py
+++ b/armada/handlers/tiller.py
@@ -32,7 +32,7 @@ RELEASE_LIMIT = 64
 # but until proper paging is supported, we need
 # to support a larger payload as the current
 # limit is exhausted with just 10 releases
-MAX_MESSAGE_LENGTH=4194304*10
+MAX_MESSAGE_LENGTH = 4010241024
 
 LOG = logging.getLogger(__name__)
 
@@ -68,9 +68,13 @@ class Tiller(object):
         '''
         tiller_ip = self._get_tiller_ip()
         tiller_port = self._get_tiller_port()
-        return grpc.insecure_channel('%s:%s' % (tiller_ip, tiller_port), options=\
-          [('grpc.max_send_message_length', MAX_MESSAGE_LENGTH), (
-            'grpc.max_receive_message_length', MAX_MESSAGE_LENGTH)])
+        return grpc.insecure_channel(
+            '%s:%s' % (tiller_ip, tiller_port),
+            options=[
+                ('grpc.max_send_message_length', MAX_MESSAGE_LENGTH),
+                ('grpc.max_receive_message_length', MAX_MESSAGE_LENGTH)
+            ]
+        )
 
     def _get_tiller_pod(self):
         '''


### PR DESCRIPTION
The long term solution is better pagination when listing
releases.  This is a short-term fix that allows a larger
message size as the 4MB built in gRPC default was being
exhausted with just 10 releases.

<!--
      Thanks for contributing to Armada!  Please be thorough
      when filling out your pull request. If the purpose for your pull
      request is not clear, we may close your pull request and ask you
      to resubmit.
-->

**What is the purpose of this pull request?**:

**What issue does this pull request address?**: Fixes #

**Notes for reviewers to consider**:

**Specific reviewers for pull request**:
