### PR TITLE
[feature] Adds setup for Armada configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+etc/*.sample
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/armada/conf/__init__.py
+++ b/armada/conf/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2017 The Armada Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from oslo_config import cfg
+
+from armada.conf import default
+
+CONF = cfg.CONF
+
+default.register_opts(CONF)

--- a/armada/conf/default.py
+++ b/armada/conf/default.py
@@ -1,0 +1,38 @@
+# Copyright 2017 The Armada Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from oslo_config import cfg
+
+default_options = [
+    cfg.StrOpt(
+        'ssh_key_path',
+        default='/home/user/.ssh/',
+        help='Path to SSH private key.'),
+
+    cfg.StrOpt(
+        'logs',
+        default='/var/log/armada/armada.log',
+        help='Path to Armada logs.'),
+
+    cfg.StrOpt(
+        'kubernetes_config_path',
+        default='/home/user/.kube/',
+        help='Path to Kubernetes configurations.')
+]
+
+def register_opts(conf):
+    conf.register_opts(default_options)
+
+def list_opts():
+    return {'DEFAULT': default_options}

--- a/armada/conf/opts.py
+++ b/armada/conf/opts.py
@@ -1,0 +1,97 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+"""Single point of entry to generate the sample configuration file.
+
+This module collects all the necessary info from the other modules in this
+package. It is assumed that:
+
+* Every other module in this package has a 'list_opts' function which
+  returns a dict where:
+
+  * The keys are strings which are the group names.
+
+  * The value of each key is a list of config options for that group.
+
+* The conf package doesn't have further packages with config options.
+
+* This module is only used in the context of sample file generation.
+
+"""
+
+import collections
+import importlib
+import os
+import pkgutil
+
+
+LIST_OPTS_FUNC_NAME = 'list_opts'
+IGNORED_MODULES = ('opts', 'constants', 'utils')
+
+
+def list_opts():
+    opts = collections.defaultdict(list)
+    module_names = _list_module_names()
+    imported_modules = _import_modules(module_names)
+    _append_config_options(imported_modules, opts)
+    return _tupleize(opts)
+
+
+def _tupleize(d):
+    """Convert a dict of options to the 2-tuple format."""
+    return [(key, value) for key, value in d.items()]
+
+
+def _list_module_names():
+    module_names = []
+    package_path = os.path.dirname(os.path.abspath(__file__))
+    for _, module_name, ispkg in pkgutil.iter_modules(path=[package_path]):
+        if module_name in IGNORED_MODULES or ispkg:
+            # Skip this module.
+            continue
+        else:
+            module_names.append(module_name)
+    return module_names
+
+
+def _import_modules(module_names):
+    imported_modules = []
+    for module_name in module_names:
+        full_module_path = '.'.join(__name__.split('.')[:-1] + [module_name])
+        module = importlib.import_module(full_module_path)
+        if not hasattr(module, LIST_OPTS_FUNC_NAME):
+            raise Exception(
+                "The module '%s' should have a '%s' function which "
+                "returns the config options." % (
+                    full_module_path,
+                    LIST_OPTS_FUNC_NAME))
+        else:
+            imported_modules.append(module)
+    return imported_modules
+
+
+def _process_old_opts(configs):
+    """Convert old-style 2-tuple configs to dicts."""
+    if isinstance(configs, tuple):
+        configs = [configs]
+    return {label: options for label, options in configs}
+
+
+def _append_config_options(imported_modules, config_options):
+    for module in imported_modules:
+        configs = module.list_opts()
+        # TODO(markus_z): Remove this compatibility shim once all list_opts()
+        # functions have been updated to return dicts.
+        if not isinstance(configs, dict):
+            configs = _process_old_opts(configs)
+        for key, val in configs.items():
+            config_options[key].extend(val)

--- a/etc/armada/config-generator.conf
+++ b/etc/armada/config-generator.conf
@@ -1,0 +1,4 @@
+[DEFAULT]
+output_file = etc/armada/armada.conf.sample
+wrap_width = 80
+namespace = armada.conf

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,8 @@ falcon==1.1.0
 gunicorn==19.7.1
 
 # CLI
-
 cliff==2.7.0
+
+# Oslo
+oslo.config>=3.22.0 # Apache-2.0
+oslo.middleware>=3.27.0 # Apache-2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,8 @@ console_scripts =
 armada =
     apply = armada.cli.apply:ApplyChartsCommand
     tiller = armada.cli.tiller:TillerServerCommand
+oslo.config.opts =
+    armada.conf = armada.conf.opts:list_opts
 
 [pbr]
 warnerrors = True

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,8 @@ commands =
 [testenv:docs]
 commands = python setup.py build_sphinx
 
+[testenv:genconfig]
+commands = oslo-config-generator --config-file=etc/armada/config-generator.conf
 
 [flake8]
 ignore=E302,H306


### PR DESCRIPTION
Enables capabilities for Armada to use centralized configuration file definitions.
* Includes oslo.config library
* Configures initial settings object structure
* Uses command ``tox -egenconfig`` to generate armada.conf template

Fixes #37 