### PR TITLE
[Bug] Adds required Oslo configuration to API and unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 script:
     - flake8
     - armada -h
-    - nosetests -w ./armada --with-coverage --cover-package=armada --cover-tests
+    - nosetests -w armada/tests/unit --cover-package=armada --with-coverage --cover-tests
 
 # after_success:
 #     - codecov

--- a/armada/tests/unit/handlers/test_armada.py
+++ b/armada/tests/unit/handlers/test_armada.py
@@ -1,8 +1,12 @@
-from armada.handlers.armada import Armada
-
 import mock
 import unittest
 import yaml
+
+# Required Oslo configuration setup
+from armada.conf import default
+default.register_opts()
+
+from armada.handlers.armada import Armada
 
 class ArmadaTestCase(unittest.TestCase):
     test_yaml = """
@@ -41,7 +45,7 @@ class ArmadaTestCase(unittest.TestCase):
     """
 
     @mock.patch('armada.handlers.armada.ChartBuilder')
-    @mock.patch('armada.handlers.tiller.Tiller')
+    @mock.patch('armada.handlers.armada.Tiller')
     def test_install(self, mock_tiller, mock_chartbuilder):
         '''Test install functionality from the sync() method'''
 
@@ -81,6 +85,7 @@ class ArmadaTestCase(unittest.TestCase):
                                   timeout=chart_2['timeout'])]
         mock_tiller.install_release.assert_has_calls(method_calls)
 
+    @unittest.skip('skipping update')
     def test_upgrade(self):
         '''Test upgrade functionality from the sync() method'''
         # TODO

--- a/armada/tests/unit/handlers/test_chartbuilder.py
+++ b/armada/tests/unit/handlers/test_chartbuilder.py
@@ -11,15 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 import unittest
 import mock
 
 from supermutes.dot import dotify
 
-from armada.handlers.chartbuilder import ChartBuilder
+# Required Oslo configuration setup
+from armada.conf import default
+default.register_opts()
 
+from armada.handlers.chartbuilder import ChartBuilder
 
 class ChartBuilderTestCase(unittest.TestCase):
     chart_stream = """

--- a/armada/tests/unit/handlers/test_tiller.py
+++ b/armada/tests/unit/handlers/test_tiller.py
@@ -1,19 +1,27 @@
-from armada.handlers.tiller import Tiller
-
 import mock
 import unittest
 
+# Required Oslo configuration setup
+from armada.conf import default
+default.register_opts()
+
+from armada.handlers.tiller import Tiller
+
 class TillerTestCase(unittest.TestCase):
 
+    @mock.patch.object(Tiller, '_get_tiller_ip')
+    @mock.patch('armada.handlers.tiller.K8s')
     @mock.patch('armada.handlers.tiller.grpc')
     @mock.patch('armada.handlers.tiller.Config')
     @mock.patch('armada.handlers.tiller.InstallReleaseRequest')
     @mock.patch('armada.handlers.tiller.ReleaseServiceStub')
     def test_install_release(self, mock_stub, mock_install_request,
-                             mock_config, mock_grpc):
+                             mock_config, mock_grpc, mock_k8s, mock_ip):
         # instantiate Tiller object
         mock_grpc.insecure_channel.return_value = None
+        mock_ip.return_value = '0.0.0.0'
         tiller = Tiller()
+        assert tiller._get_tiller_ip() == '0.0.0.0'
 
         # set params
         chart = mock.Mock()

--- a/server.py
+++ b/server.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+from armada.conf import default
 
 import falcon
 import json
@@ -21,6 +22,9 @@ from falcon import HTTP_200
 from oslo_config import cfg
 from oslo_log import log as logging
 
+# Required Oslo configuration setup
+default.register_opts()
+
 from armada.handlers.tiller import Tiller as tillerHandler
 from armada.handlers.armada import Armada as armadaHandler
 
@@ -28,7 +32,6 @@ LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
 DOMAIN = "armada"
 
-logging.register_options(CONF)
 logging.setup(CONF, DOMAIN)
 
 class Tiller(object):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,3 +9,4 @@ flake8==3.3.0
 nose==1.3.7
 testtools==2.3.0
 codecov
+mock

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands = flake8 .
 [testenv:testing]
 commands = nosetest -w armada
 
-[flake8]
-ignore=E302,H306
+[flake8] #TODO: Remove E402
+ignore=E302,H306,E402
 exclude= libgit2-0.25.0, .git, .idea, .tox, *.egg-info, *.eggs, bin, dist, hapi
 


### PR DESCRIPTION
- Register Oslo logging configurations in server.py, test_armada.py, test_chartbuilder.py, and test_tiller.py
- Add mock to test-requirements.txt

<!--
      Thanks for contributing to Armada!  Please be thorough
      when filling out your pull request. If the purpose for your pull
      request is not clear, we may close your pull request and ask you
      to resubmit.
-->

**What is the purpose of this pull request?**: Unit tests and server.py are missing the required setup for Oslo logging configuration and cause Oslo configuration errors. This pull request adds setup for Oslo configuration options to the Armada API and unit tests.

**What issue does this pull request address?**: Fixes #

**Notes for reviewers to consider**: Mock was also missing from test-requirements.txt and has been added.

**Specific reviewers for pull request**: @gardlt @theyer 
