### PR TITLE
[Bug] Update default timeout and logic

### DIFF
--- a/armada/handlers/armada.py
+++ b/armada/handlers/armada.py
@@ -27,6 +27,7 @@ from ..utils import lint
 
 LOG = logging.getLogger(__name__)
 
+DEFAULT_TIMEOUT = 3600
 CONF = cfg.CONF
 DOMAIN = "armada"
 
@@ -45,7 +46,7 @@ class Armada(object):
                  skip_pre_flight=False,
                  dry_run=False,
                  wait=False,
-                 timeout=None,
+                 timeout=DEFAULT_TIMEOUT,
                  debug=False):
         '''
         Initialize the Armada Engine and establish
@@ -131,12 +132,11 @@ class Armada(object):
                     continue
 
                 # retrieve appropriate timeout value if 'wait' is specified
-                chart_timeout = None
+                chart_timeout = self.timeout
                 if chart_wait:
-                    if getattr(chart, 'timeout', None):
-                        chart_timeout = chart.timeout
-                    else:
-                        chart_timeout = self.timeout
+                    if chart_timeout == DEFAULT_TIMEOUT:
+                        chart_timeout = getattr(chart, 'timeout',
+                                                chart_timeout)
 
                 chartbuilder = ChartBuilder(chart)
                 protoc_chart = chartbuilder.get_helm_chart()

--- a/armada/tests/unit/handlers/test_armada.py
+++ b/armada/tests/unit/handlers/test_armada.py
@@ -52,7 +52,7 @@ class ArmadaTestCase(unittest.TestCase):
         armada = Armada('',
                         skip_pre_flight=True,
                         wait=True,
-                        timeout=None)
+                        timeout=1000)
         armada.tiller = mock_tiller
         armada.config = yaml.load(self.test_yaml)
 
@@ -75,14 +75,14 @@ class ArmadaTestCase(unittest.TestCase):
                                   armada.config['armada']['release_prefix'],
                                   values=yaml.safe_dump(chart_1['values']),
                                   wait=armada.wait,
-                                  timeout=chart_1['timeout']),
+                                  timeout=1000),
                         mock.call(mock_chartbuilder().get_helm_chart(),
                                   armada.dry_run, chart_2['release_name'],
                                   chart_2['namespace'],
                                   armada.config['armada']['release_prefix'],
                                   values=yaml.safe_dump(chart_2['values']),
                                   wait=armada.wait,
-                                  timeout=chart_2['timeout'])]
+                                  timeout=1000)]
         mock_tiller.install_release.assert_has_calls(method_calls)
 
     @unittest.skip('skipping update')


### PR DESCRIPTION
- Change default timeout to 3600
- Timeout specified with CLI has priority
- Timeout specified with yaml has second priority

<!--
      Thanks for contributing to Armada!  Please be thorough
      when filling out your pull request. If the purpose for your pull
      request is not clear, we may close your pull request and ask you
      to resubmit.
-->

**What is the purpose of this pull request?**: The default timeout was previously set to "None". This PR corrects that.

**What issue does this pull request address?**: Fixes #

**Notes for reviewers to consider**: 

**Specific reviewers for pull request**: @gardlt @theyer @alanmeadows 
