### PR TITLE
Ensure armada has ownership over its own home directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && \
       libffi-dev \
       python-all-dev && \
     useradd -u 1000 -g users -d /armada armada && \
+    chown armada:users /armada && \
     \
     curl -sSL https://github.com/libgit2/libgit2/archive/v$LIBGIT_VERSION.tar.gz \
       | tar zx -C /tmp && \


### PR DESCRIPTION
**What is the purpose of this pull request?**: The recent change to have the armada container as the armada user overlooked providing the armada user ownership over its own home directory.  Fixing this should help allow docker volume mounts as root into this directory (such as the kubeconfg) to function properly.