### PR TITLE
Fix oslo_config and oslo_log configurations

### DIFF
--- a/armada/api/armada_controller.py
+++ b/armada/api/armada_controller.py
@@ -11,9 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-
-from armada.conf import default
 
 import json
 from falcon import HTTP_200
@@ -21,16 +18,11 @@ from falcon import HTTP_200
 from oslo_config import cfg
 from oslo_log import log as logging
 
-# Required Oslo configuration setup
-default.register_opts()
-
 from armada.handlers.armada import Armada as Handler
 
 LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
-DOMAIN = "armada"
 
-logging.setup(CONF, DOMAIN)
 
 class Apply(object):
     '''

--- a/armada/api/middleware.py
+++ b/armada/api/middleware.py
@@ -12,24 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from armada.conf import default
-
-# Required Oslo configuration setup
-default.register_opts()
+import falcon
 
 from keystoneauth1 import session
 from keystoneauth1.identity import v3
-
 from oslo_config import cfg
 from oslo_log import log as logging
 
-import falcon
-
 LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
-DOMAIN = "armada"
 
-logging.setup(CONF, DOMAIN)
 
 class AuthMiddleware(object):
 

--- a/armada/api/server.py
+++ b/armada/api/server.py
@@ -11,31 +11,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-
-from armada.conf import default
-
-# Required Oslo configuration setup
-default.register_opts()
-
-from armada_controller import Apply
-from tiller_controller import Release, Status
-
-from middleware import AuthMiddleware, RoleMiddleware
 
 import falcon
 
 from oslo_config import cfg
 from oslo_log import log as logging
 
-LOG = logging.getLogger(__name__)
-CONF = cfg.CONF
-DOMAIN = "armada"
+import armada.conf as configs
 
-logging.setup(CONF, DOMAIN)
+from armada_controller import Apply
+from middleware import AuthMiddleware
+from middleware import RoleMiddleware
+from tiller_controller import Release
+from tiller_controller import Status
+
+LOG = logging.getLogger(__name__)
+configs.set_app_default_configs()
+CONF = cfg.CONF
 
 # Build API
 def create(middleware=CONF.middleware):
+    logging.register_options(CONF)
+    logging.set_defaults(default_log_levels=CONF.default_log_levels)
+    logging.setup(CONF, 'armada')
+
     if middleware:
         api = falcon.API(middleware=[AuthMiddleware(), RoleMiddleware()])
     else:

--- a/armada/api/tiller_controller.py
+++ b/armada/api/tiller_controller.py
@@ -11,9 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-
-from armada.conf import default
 
 import json
 from falcon import HTTP_200
@@ -21,16 +18,11 @@ from falcon import HTTP_200
 from oslo_config import cfg
 from oslo_log import log as logging
 
-# Required Oslo configuration setup
-default.register_opts()
-
 from armada.handlers.tiller import Tiller as tillerHandler
 
 LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
-DOMAIN = "armada"
 
-logging.setup(CONF, DOMAIN)
 
 class Status(object):
     def on_get(self, req, resp):

--- a/armada/cli/tiller.py
+++ b/armada/cli/tiller.py
@@ -22,9 +22,6 @@ from oslo_log import log as logging
 LOG = logging.getLogger(__name__)
 
 CONF = cfg.CONF
-DOMAIN = "armada"
-
-logging.setup(CONF, DOMAIN)
 
 def tillerServer(args):
 

--- a/armada/cli/validate.py
+++ b/armada/cli/validate.py
@@ -24,9 +24,6 @@ from oslo_log import log as logging
 LOG = logging.getLogger(__name__)
 
 CONF = cfg.CONF
-DOMAIN = "armada"
-
-logging.setup(CONF, DOMAIN)
 
 def validateYaml(args):
     documents = yaml.safe_load_all(open(args.file).read())

--- a/armada/conf/__init__.py
+++ b/armada/conf/__init__.py
@@ -11,3 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import os
+
+from oslo_config import cfg
+
+from armada.conf import default
+
+CONF = cfg.CONF
+
+# Load config file if exists
+if (os.path.exists('etc/armada/armada.conf')):
+    CONF(['--config-file', 'etc/armada/armada.conf'])
+
+def set_app_default_configs():
+    default.register_opts(CONF)

--- a/armada/conf/default.py
+++ b/armada/conf/default.py
@@ -1,208 +1,75 @@
 # Copyright 2017 The Armada Authors.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License, Version 2.0 (the 'License'));
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the License is distributed on an 'AS IS' BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 from oslo_config import cfg
+
+from armada.conf import utils
 
 default_options = [
 
     cfg.ListOpt(
         'armada_apply_roles',
         default=['admin'],
-        help='IDs of approved API access roles.'),
+        help=utils.fmt('IDs of approved API access roles.')),
 
     cfg.StrOpt(
         'auth_url',
         default='http://0.0.0.0/v3',
-        help='The default Keystone authentication url.'),
-
-    cfg.BoolOpt(
-        'debug',
-        default='false',
-        help='Print debugging output (set logging level to DEBUG instead of \
-        default INFO level).'),
-
-    cfg.ListOpt(
-        'default_log_levels',
-        default='root=INFO, cliff=INFO, stevedore=INFO, iso8601=INFO',
-        help='List of logger=LEVEL pairs.'),
-
-    cfg.BoolOpt(
-        'fatal_deprecations',
-        default='true',
-        help='Enables or disables fatal status of deprecations.'),
+        help=utils.fmt('The default Keystone authentication url.')),
 
     cfg.StrOpt(
         'kubernetes_config_path',
         default='/home/user/.kube/',
-        help='Path to Kubernetes configurations.'),
-
-    cfg.StrOpt(
-        'instance_format',
-        default='[instance: %(uuid)s] ',
-        help='The format for an instance that is passed \
-        with the log message.'),
-
-    cfg.StrOpt(
-        'instance_uuid_format',
-        default='[instance: %(uuid)s] ',
-        help='The format for an instance UUID that is passed \
-        with the log message.'),
-
-    cfg.StrOpt(
-        'log_config_append',
-        default=None,
-        help='The name of a logging configuration file.'),
-
-    cfg.StrOpt(
-        'log_date_format',
-        default='%Y-%m-%d %H:%M:%S',
-        help='Date format for log records.'),
-
-    cfg.StrOpt(
-        'log_dir',
-        default=None,
-        help='(Optional) The base directory used for \
-        relative log file paths.'),
-
-    cfg.StrOpt(
-        'log_file',
-        default=None,
-        help='(Optional) Path to Armada log file.'),
-
-    cfg.StrOpt(
-        'logging_context_format_string',
-        default='%(asctime)s.%(msecs)03d %(process)d %(levelname)s \
-        %(name)s [%(request_id)s %(user_identity)s] \
-        %(instance)s%(message)s',
-        help='Format for context logging.'),
-
-    cfg.StrOpt(
-        'logging_debug_format_suffix',
-        default='%(funcName)s %(pathname)s:%(lineno)d',
-        help='Format string to use for log messages \
-        when context is undefined.'),
-
-    cfg.StrOpt(
-        'logging_default_format_string',
-        default='%(asctime)s.%(msecs)03d %(process)d \
-        %(levelname)s %(name)s [-] %(instance)s%(message)s',
-        help='Format string to use for log \
-        messages when context is undefined.'),
-
-    cfg.StrOpt(
-        'logging_exception_prefix',
-        default='%(asctime)s.%(msecs)03d %(process)d \
-        ERROR %(name)s %(instance)s',
-        help='Prefix each line of \
-        exception output with this format.'),
-
-    cfg.StrOpt(
-        'logging_user_identity_format',
-        default='%(user)s %(tenant)s %(domain)s \
-        %(user_domain)s %(project_domain)s',
-        help='Defines the format string for \
-        %(user_identity)s that is used in logging_context_format_string.'),
+        help=utils.fmt('Path to Kubernetes configurations.')),
 
     cfg.BoolOpt(
         'middleware',
         default='true',
-        help='Enables or disables Keystone authentication middleware.'),
+        help=utils.fmt("""
+Enables or disables Keystone authentication middleware.
+""")),
 
     cfg.StrOpt(
         'project_domain_name',
         default='default',
-        help='The Keystone project domain name used for authentication.'),
+        help=utils.fmt("""
+The Keystone project domain name used for authentication.
+""")),
 
     cfg.StrOpt(
         'project_name',
         default='admin',
-        help='The Keystone project name used for authentication.'),
-
-    cfg.BoolOpt(
-        'publish_errors',
-        default='true',
-        help='Enables or disables publication of error events.'),
-
-    cfg.IntOpt(
-        'rate_limit_burst',
-        default='0',
-        help='Maximum number of logged messages per rate_limit_interval.'),
-
-    cfg.StrOpt(
-        'rate_limit_except_level',
-        default='CRITICAL',
-        help='Log level name used by rate limiting: \
-        CRITICAL, ERROR, INFO, WARNING, DEBUG'),
-
-    cfg.IntOpt(
-        'rate_limit_interval',
-        default='0',
-        help='Maximum number of logged messages per rate_limit_interval.'),
+        help=utils.fmt('The Keystone project name used for authentication.')),
 
     cfg.StrOpt(
         'ssh_key_path',
         default='/home/user/.ssh/',
-        help='Path to SSH private key.'),
-
-    cfg.StrOpt(
-        'syslog_log_facility',
-        default='LOG_USER',
-        help='Syslog facility to receive log lines. \
-        This option is ignored if log_config_append is set.'),
-
-    cfg.BoolOpt(
-        'use_journal',
-        default='false',
-        help='Enable journald for logging. (Must be a systemd environment)'),
-
-    cfg.BoolOpt(
-        'use_stderr',
-        default='true',
-        help='Log output to standard error.'),
-
-    cfg.BoolOpt(
-        'use_syslog',
-        default='true',
-        help='Log output to syslog.'),
+        help=utils.fmt('Path to SSH private key.')),
 
     cfg.ListOpt(
         'tiller_release_roles',
         default=['admin'],
-        help='IDs of approved API access roles.'),
+        help=utils.fmt('IDs of approved API access roles.')),
 
     cfg.ListOpt(
         'tiller_status_roles',
         default=['admin'],
-        help='IDs of approved API access roles.'),
-
-    cfg.BoolOpt(
-        'watch_log_file',
-        default='false',
-        help='Enables instantaneous recreation of a \
-        logging file if the file is removed.')
+        help=utils.fmt('IDs of approved API access roles.'))
 ]
 
-def register_opts():
-    CONF = cfg.CONF
-    CONF.register_opts(default_options)
-
-    # Load config file if exists
-    default_config_file = 'etc/armada/armada.conf'
-    if (os.path.exists(default_config_file)):
-        CONF(['--config-file', default_config_file])
+def register_opts(conf):
+    conf.register_opts(default_options)
 
 def list_opts():
     return {'DEFAULT': default_options}

--- a/armada/conf/utils.py
+++ b/armada/conf/utils.py
@@ -1,0 +1,26 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+
+def fmt(docstr):
+    """Format a docstring for use as documentation in sample config."""
+    # Replace newlines with spaces, as docstrings contain literal newlines that
+    # should not be rendered into the sample configuration file (instead, line
+    # wrappings should be applied automatically).
+    docstr = docstr.replace('\n', ' ')
+
+    # Because it's common for docstrings to begin and end with a newline, there
+    # is now whitespace at the beginning and end of the documentation as a side
+    # effect of replacing newlines with spaces.
+    docstr = docstr.strip()
+
+    return docstr

--- a/armada/exceptions/base_exception.py
+++ b/armada/exceptions/base_exception.py
@@ -19,9 +19,7 @@ LOG = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT = 3600
 CONF = cfg.CONF
-DOMAIN = "armada"
 
-logging.setup(CONF, DOMAIN)
 
 class ArmadaBaseException(Exception):
     '''Base class for Armada exception and error handling.'''

--- a/armada/handlers/armada.py
+++ b/armada/handlers/armada.py
@@ -38,9 +38,6 @@ LOG = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT = 3600
 CONF = cfg.CONF
-DOMAIN = "armada"
-
-logging.setup(CONF, DOMAIN)
 
 
 class Armada(object):
@@ -77,8 +74,9 @@ class Armada(object):
         self.debug = debug
 
         # Set debug value
-        CONF.set_default('debug', self.debug)
-        logging.setup(CONF, DOMAIN)
+        # Define a default handler at INFO logging level
+        if self.debug:
+            logging.basicConfig(level=logging.DEBUG)
 
     def get_armada_manifest(self):
         return Manifest(self.documents).get_manifest()

--- a/armada/handlers/chartbuilder.py
+++ b/armada/handlers/chartbuilder.py
@@ -29,9 +29,6 @@ from oslo_log import log as logging
 LOG = logging.getLogger(__name__)
 
 CONF = cfg.CONF
-DOMAIN = "armada"
-
-logging.setup(CONF, DOMAIN)
 
 
 class ChartBuilder(object):

--- a/armada/handlers/k8s.py
+++ b/armada/handlers/k8s.py
@@ -22,9 +22,6 @@ from oslo_log import log as logging
 LOG = logging.getLogger(__name__)
 
 CONF = cfg.CONF
-DOMAIN = "armada"
-
-logging.setup(CONF, DOMAIN)
 
 
 class K8s(object):

--- a/armada/handlers/tiller.py
+++ b/armada/handlers/tiller.py
@@ -43,9 +43,6 @@ MAX_MESSAGE_LENGTH = 429496729
 LOG = logging.getLogger(__name__)
 
 CONF = cfg.CONF
-DOMAIN = "armada"
-
-logging.setup(CONF, DOMAIN)
 
 
 class Tiller(object):

--- a/armada/shell.py
+++ b/armada/shell.py
@@ -14,11 +14,14 @@
 
 import sys
 
+from oslo_config import cfg
+from oslo_log import log
 from cliff import app
 from cliff import commandmanager as cm
-from conf import default
 
 import armada
+
+CONF = cfg.CONF
 
 class ArmadaApp(app.App):
     def __init__(self, **kwargs):
@@ -35,7 +38,9 @@ class ArmadaApp(app.App):
 
     def configure_logging(self):
         super(ArmadaApp, self).configure_logging()
-        default.register_opts()
+        log.register_options(CONF)
+        log.set_defaults(default_log_levels=CONF.default_log_levels)
+        log.setup(CONF, 'armada')
 
 def main(argv=None):
     if argv is None:

--- a/armada/tests/unit/handlers/test_armada.py
+++ b/armada/tests/unit/handlers/test_armada.py
@@ -2,12 +2,9 @@ import mock
 import unittest
 import yaml
 
-# Required Oslo configuration setup
-from armada.conf import default
-default.register_opts()
-
 from armada.handlers.armada import Armada
 from armada.handlers.manifest import Manifest
+
 
 class ArmadaTestCase(unittest.TestCase):
     test_yaml = """

--- a/armada/tests/unit/handlers/test_chartbuilder.py
+++ b/armada/tests/unit/handlers/test_chartbuilder.py
@@ -14,11 +14,8 @@
 import unittest
 import mock
 
-# Required Oslo configuration setup
-from armada.conf import default
-default.register_opts()
-
 from armada.handlers.chartbuilder import ChartBuilder
+
 
 class ChartBuilderTestCase(unittest.TestCase):
     chart_stream = """

--- a/armada/tests/unit/handlers/test_tiller.py
+++ b/armada/tests/unit/handlers/test_tiller.py
@@ -1,11 +1,8 @@
 import mock
 import unittest
 
-# Required Oslo configuration setup
-from armada.conf import default
-default.register_opts()
-
 from armada.handlers.tiller import Tiller
+
 
 class TillerTestCase(unittest.TestCase):
 

--- a/etc/armada/armada.conf.sample
+++ b/etc/armada/armada.conf.sample
@@ -1,0 +1,140 @@
+[DEFAULT]
+
+#
+# From armada.conf
+#
+
+# IDs of approved API access roles. (list value)
+#armada_apply_roles = admin
+
+# The default Keystone authentication url. (string value)
+#auth_url = http://0.0.0.0/v3
+
+# Path to Kubernetes configurations. (string value)
+#kubernetes_config_path = /home/user/.kube/
+
+# Enables or disables Keystone authentication middleware. (boolean value)
+#middleware = true
+
+# The Keystone project domain name used for authentication. (string value)
+#project_domain_name = default
+
+# The Keystone project name used for authentication. (string value)
+#project_name = admin
+
+# Path to SSH private key. (string value)
+#ssh_key_path = /home/user/.ssh/
+
+# IDs of approved API access roles. (list value)
+#tiller_release_roles = admin
+
+# IDs of approved API access roles. (list value)
+#tiller_status_roles = admin
+
+#
+# From oslo.log
+#
+
+# If set to true, the logging level will be set to DEBUG instead of the default
+# INFO level. (boolean value)
+# Note: This option can be changed without restarting.
+#debug = false
+
+# The name of a logging configuration file. This file is appended to any
+# existing logging configuration files. For details about logging configuration
+# files, see the Python logging module documentation. Note that when logging
+# configuration files are used then all logging configuration is set in the
+# configuration file and other logging configuration options are ignored (for
+# example, logging_context_format_string). (string value)
+# Note: This option can be changed without restarting.
+# Deprecated group/name - [DEFAULT]/log_config
+#log_config_append = <None>
+
+# Defines the format string for %%(asctime)s in log records. Default:
+# %(default)s . This option is ignored if log_config_append is set. (string
+# value)
+#log_date_format = %Y-%m-%d %H:%M:%S
+
+# (Optional) Name of log file to send logging output to. If no default is set,
+# logging will go to stderr as defined by use_stderr. This option is ignored if
+# log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logfile
+#log_file = <None>
+
+# (Optional) The base directory used for relative log_file  paths. This option
+# is ignored if log_config_append is set. (string value)
+# Deprecated group/name - [DEFAULT]/logdir
+#log_dir = <None>
+
+# Uses logging handler designed to watch file system. When log file is moved or
+# removed this handler will open a new log file with specified path
+# instantaneously. It makes sense only if log_file option is specified and Linux
+# platform is used. This option is ignored if log_config_append is set. (boolean
+# value)
+#watch_log_file = false
+
+# Use syslog for logging. Existing syslog format is DEPRECATED and will be
+# changed later to honor RFC5424. This option is ignored if log_config_append is
+# set. (boolean value)
+#use_syslog = false
+
+# Enable journald for logging. If running in a systemd environment you may wish
+# to enable journal support. Doing so will use the journal native protocol which
+# includes structured metadata in addition to log messages.This option is
+# ignored if log_config_append is set. (boolean value)
+#use_journal = false
+
+# Syslog facility to receive log lines. This option is ignored if
+# log_config_append is set. (string value)
+#syslog_log_facility = LOG_USER
+
+# Log output to standard error. This option is ignored if log_config_append is
+# set. (boolean value)
+#use_stderr = false
+
+# Format string to use for log messages with context. (string value)
+#logging_context_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s %(user_identity)s] %(instance)s%(message)s
+
+# Format string to use for log messages when context is undefined. (string
+# value)
+#logging_default_format_string = %(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s
+
+# Additional data to append to log message when logging level for the message is
+# DEBUG. (string value)
+#logging_debug_format_suffix = %(funcName)s %(pathname)s:%(lineno)d
+
+# Prefix each line of exception output with this format. (string value)
+#logging_exception_prefix = %(asctime)s.%(msecs)03d %(process)d ERROR %(name)s %(instance)s
+
+# Defines the format string for %(user_identity)s that is used in
+# logging_context_format_string. (string value)
+#logging_user_identity_format = %(user)s %(tenant)s %(domain)s %(user_domain)s %(project_domain)s
+
+# List of package logging levels in logger=LEVEL pairs. This option is ignored
+# if log_config_append is set. (list value)
+#default_log_levels = amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,oslo_messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN,urllib3.connectionpool=WARN,websocket=WARN,requests.packages.urllib3.util.retry=WARN,urllib3.util.retry=WARN,keystonemiddleware=WARN,routes.middleware=WARN,stevedore=WARN,taskflow=WARN,keystoneauth=WARN,oslo.cache=INFO,dogpile.core.dogpile=INFO
+
+# Enables or disables publication of error events. (boolean value)
+#publish_errors = false
+
+# The format for an instance that is passed with the log message. (string value)
+#instance_format = "[instance: %(uuid)s] "
+
+# The format for an instance UUID that is passed with the log message. (string
+# value)
+#instance_uuid_format = "[instance: %(uuid)s] "
+
+# Interval, number of seconds, of log rate limiting. (integer value)
+#rate_limit_interval = 0
+
+# Maximum number of logged messages per rate_limit_interval. (integer value)
+#rate_limit_burst = 0
+
+# Log level name used by rate limiting: CRITICAL, ERROR, INFO, WARNING, DEBUG or
+# empty string. Logs with level greater or equal to rate_limit_except_level are
+# not filtered. An empty string means that all levels are filtered. (string
+# value)
+#rate_limit_except_level = CRITICAL
+
+# Enables or disables fatal status of deprecations. (boolean value)
+#fatal_deprecations = false

--- a/etc/armada/config-generator.conf
+++ b/etc/armada/config-generator.conf
@@ -2,3 +2,4 @@
 output_file = etc/armada/armada.conf.sample
 wrap_width = 80
 namespace = armada.conf
+namespace = oslo.log

--- a/examples/simple.yaml
+++ b/examples/simple.yaml
@@ -24,7 +24,10 @@ data:
   chart_name: blog-2
   release: blog-2
   namespace: default
-  values: {}
+  values:
+    some: value
+  upgrade:
+    no_hooks: false
   source:
     type: git
     location: https://github.com/gardlt/hello-world-chart

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,8 +40,6 @@ armada =
     apply = armada.cli.apply:ApplyChartsCommand
     tiller = armada.cli.tiller:TillerServerCommand
     validate = armada.cli.validate:ValidateYamlCommand
-oslo.config.opts =
-    armada.conf = armada.conf.opts:list_opts
 
 [pbr]
 warnerrors = True


### PR DESCRIPTION
* Ensure that configurations are done via the global `cfg` object
* Ensure that the logger is configure through the global object
* Upload a configuration sample file with DEFAULT section having
  the armada.conf and oslo_log namespace

<!--
      Thanks for contributing to Armada!  Please be thorough
      when filling out your pull request. If the purpose for your pull
      request is not clear, we may close your pull request and ask you
      to resubmit.
-->

**What is the purpose of this pull request?**: Address the proper configurations of the oslo_log and oslo_config libraries for use within Armada

**What issue does this pull request address?**: Fixes #112

**Notes for reviewers to consider**:

**Specific reviewers for pull request**: @gardlt @drewwalters96 @theyer 
